### PR TITLE
Add admin area and dynamic blog content

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -1,0 +1,68 @@
+<?php
+session_start();
+
+const ADMIN_USER = 'admin';
+const ADMIN_PASS = 'admin123';
+const DATA_FILE = __DIR__ . '/../data/site-data.json';
+
+function load_data(): array
+{
+    if (!file_exists(DATA_FILE)) {
+        return [
+            'stats' => [
+                'services' => 0,
+                'clients' => 0,
+                'experience' => 0,
+            ],
+            'blogs' => [],
+        ];
+    }
+
+    $json = file_get_contents(DATA_FILE);
+    $data = json_decode($json, true);
+
+    if (!is_array($data)) {
+        return [
+            'stats' => [
+                'services' => 0,
+                'clients' => 0,
+                'experience' => 0,
+            ],
+            'blogs' => [],
+        ];
+    }
+
+    $data['stats'] = $data['stats'] ?? [];
+    $data['blogs'] = $data['blogs'] ?? [];
+
+    return $data;
+}
+
+function save_data(array $data): void
+{
+    $dir = dirname(DATA_FILE);
+    if (!is_dir($dir)) {
+        mkdir($dir, 0775, true);
+    }
+
+    $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+    file_put_contents(DATA_FILE, $json, LOCK_EX);
+}
+
+function ensure_logged_in(): void
+{
+    if (empty($_SESSION['admin_logged_in'])) {
+        header('Location: login.php');
+        exit;
+    }
+}
+
+function slugify(string $text): string
+{
+    $text = iconv('UTF-8', 'ASCII//TRANSLIT', $text);
+    $text = preg_replace('~[^\pL\d]+~u', '-', $text);
+    $text = trim($text, '-');
+    $text = strtolower($text);
+    $text = preg_replace('~[^-a-z0-9]+~', '', $text);
+    return $text ?: 'post-' . uniqid();
+}

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,0 +1,165 @@
+<?php
+require_once __DIR__ . '/config.php';
+ensure_logged_in();
+$data = load_data();
+$stats = array_merge([
+    'services' => 0,
+    'clients' => 0,
+    'experience' => 0,
+], $data['stats']);
+$blogs = $data['blogs'];
+?>
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="UTF-8">
+    <title>Painel | Área Administrativa</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
+    <style>
+        body {background:#f5f7fb;}
+        header {background:#052c65;color:#fff;padding:20px 0;margin-bottom:30px;}
+        .card {box-shadow:0 8px 20px rgba(0,0,0,0.05);}
+        textarea {min-height:140px;}
+        .blog-card + .blog-card {margin-top:1.5rem;}
+    </style>
+</head>
+<body>
+<header>
+    <div class="container d-flex justify-content-between align-items-center">
+        <h1 class="h4 mb-0">Painel Administrativo</h1>
+        <a class="btn btn-outline-light btn-sm" href="logout.php">Sair</a>
+    </div>
+</header>
+<div class="container mb-5">
+    <div class="row">
+        <div class="col-lg-6">
+            <div class="card mb-4">
+                <div class="card-header bg-white">
+                    <strong>Indicadores da página inicial</strong>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="save_stats.php">
+                        <div class="form-group">
+                            <label for="services">Serviços Concluídos</label>
+                            <input type="number" min="0" class="form-control" id="services" name="services" value="<?php echo (int) $stats['services']; ?>" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="clients">Clientes Satisfeitos</label>
+                            <input type="number" min="0" class="form-control" id="clients" name="clients" value="<?php echo (int) $stats['clients']; ?>" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="experience">Anos de Experiência</label>
+                            <input type="number" min="0" class="form-control" id="experience" name="experience" value="<?php echo (int) $stats['experience']; ?>" required>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Guardar indicadores</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card mb-4">
+                <div class="card-header bg-white">
+                    <strong>Novo artigo do blog</strong>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="save_blog.php">
+                        <input type="hidden" name="action" value="create">
+                        <div class="form-group">
+                            <label for="title">Título</label>
+                            <input type="text" class="form-control" id="title" name="title" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="date">Data</label>
+                            <input type="date" class="form-control" id="date" name="date" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="author">Autor</label>
+                            <input type="text" class="form-control" id="author" name="author" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="image">Imagem (caminho relativo ex: images/image_1.jpg)</label>
+                            <input type="text" class="form-control" id="image" name="image" placeholder="images/image_1.jpg" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="excerpt">Resumo</label>
+                            <textarea class="form-control" id="excerpt" name="excerpt" required></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label for="content">Conteúdo completo</label>
+                            <textarea class="form-control" id="content" name="content" required></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-success">Publicar</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <h2 class="h5 mb-3">Artigos publicados</h2>
+    <?php if (empty($blogs)): ?>
+        <div class="alert alert-info">Ainda não existem artigos publicados.</div>
+    <?php endif; ?>
+    <?php foreach ($blogs as $blog): ?>
+        <div class="card blog-card">
+            <div class="card-body">
+                <h3 class="h5"><?php echo htmlspecialchars($blog['title'], ENT_QUOTES, 'UTF-8'); ?></h3>
+                <p class="mb-1 text-muted">Slug: <code><?php echo htmlspecialchars($blog['slug'], ENT_QUOTES, 'UTF-8'); ?></code></p>
+                <p class="mb-1"><strong>Data:</strong> <?php echo htmlspecialchars($blog['date'], ENT_QUOTES, 'UTF-8'); ?> | <strong>Autor:</strong> <?php echo htmlspecialchars($blog['author'], ENT_QUOTES, 'UTF-8'); ?></p>
+                <p class="mb-3"><strong>Resumo:</strong> <?php echo nl2br(htmlspecialchars($blog['excerpt'], ENT_QUOTES, 'UTF-8')); ?></p>
+                <details>
+                    <summary>Ver conteúdo completo</summary>
+                    <div class="mt-2 border rounded p-3 bg-light">
+                        <?php echo nl2br(htmlspecialchars($blog['content'], ENT_QUOTES, 'UTF-8')); ?>
+                    </div>
+                </details>
+                <div class="mt-3">
+                    <form class="d-inline-block" method="post" action="save_blog.php">
+                        <input type="hidden" name="action" value="delete">
+                        <input type="hidden" name="slug" value="<?php echo htmlspecialchars($blog['slug'], ENT_QUOTES, 'UTF-8'); ?>">
+                        <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('Eliminar este artigo?');">Eliminar</button>
+                    </form>
+                </div>
+            </div>
+            <div class="card-footer bg-white">
+                <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#edit-<?php echo htmlspecialchars($blog['slug'], ENT_QUOTES, 'UTF-8'); ?>">Editar artigo</button>
+            </div>
+            <div class="collapse" id="edit-<?php echo htmlspecialchars($blog['slug'], ENT_QUOTES, 'UTF-8'); ?>">
+                <div class="card-body border-top">
+                    <form method="post" action="save_blog.php">
+                        <input type="hidden" name="action" value="update">
+                        <input type="hidden" name="slug" value="<?php echo htmlspecialchars($blog['slug'], ENT_QUOTES, 'UTF-8'); ?>">
+                        <div class="form-group">
+                            <label>Título</label>
+                            <input type="text" class="form-control" name="title" value="<?php echo htmlspecialchars($blog['title'], ENT_QUOTES, 'UTF-8'); ?>" required>
+                        </div>
+                        <div class="form-group">
+                            <label>Data</label>
+                            <input type="date" class="form-control" name="date" value="<?php echo htmlspecialchars($blog['date'], ENT_QUOTES, 'UTF-8'); ?>" required>
+                        </div>
+                        <div class="form-group">
+                            <label>Autor</label>
+                            <input type="text" class="form-control" name="author" value="<?php echo htmlspecialchars($blog['author'], ENT_QUOTES, 'UTF-8'); ?>" required>
+                        </div>
+                        <div class="form-group">
+                            <label>Imagem</label>
+                            <input type="text" class="form-control" name="image" value="<?php echo htmlspecialchars($blog['image'], ENT_QUOTES, 'UTF-8'); ?>" required>
+                        </div>
+                        <div class="form-group">
+                            <label>Resumo</label>
+                            <textarea class="form-control" name="excerpt" required><?php echo htmlspecialchars($blog['excerpt'], ENT_QUOTES, 'UTF-8'); ?></textarea>
+                        </div>
+                        <div class="form-group">
+                            <label>Conteúdo</label>
+                            <textarea class="form-control" name="content" required><?php echo htmlspecialchars($blog['content'], ENT_QUOTES, 'UTF-8'); ?></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Guardar alterações</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    <?php endforeach; ?>
+</div>
+<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+$error = '';
+if (!empty($_SESSION['admin_logged_in'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    if ($username === ADMIN_USER && $password === ADMIN_PASS) {
+        $_SESSION['admin_logged_in'] = true;
+        header('Location: dashboard.php');
+        exit;
+    }
+
+    $error = 'Credenciais inválidas. Por favor, tente novamente.';
+}
+?>
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+    <meta charset="UTF-8">
+    <title>Login | Área Administrativa</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
+    <style>
+        body {background:#f8f9fa;}
+        .login-wrapper {max-width:420px;margin:80px auto;padding:30px;background:#fff;border-radius:8px;box-shadow:0 10px 30px rgba(0,0,0,0.08);} 
+    </style>
+</head>
+<body>
+<div class="login-wrapper">
+    <h2 class="mb-4 text-center">Área Administrativa</h2>
+    <?php if ($error): ?>
+        <div class="alert alert-danger"><?php echo htmlspecialchars($error, ENT_QUOTES, 'UTF-8'); ?></div>
+    <?php endif; ?>
+    <form method="post" autocomplete="off">
+        <div class="form-group">
+            <label for="username">Usuário</label>
+            <input type="text" class="form-control" id="username" name="username" required>
+        </div>
+        <div class="form-group">
+            <label for="password">Senha</label>
+            <input type="password" class="form-control" id="password" name="password" required>
+        </div>
+        <button type="submit" class="btn btn-primary btn-block">Entrar</button>
+    </form>
+</div>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__ . '/config.php';
+$_SESSION = [];
+session_destroy();
+header('Location: login.php');
+exit;

--- a/admin/save_blog.php
+++ b/admin/save_blog.php
@@ -1,0 +1,94 @@
+<?php
+require_once __DIR__ . '/config.php';
+ensure_logged_in();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$action = $_POST['action'] ?? '';
+$data = load_data();
+$blogs = $data['blogs'];
+
+if ($action === 'create' || $action === 'update') {
+    $title = trim($_POST['title'] ?? '');
+    $date = trim($_POST['date'] ?? '');
+    $author = trim($_POST['author'] ?? '');
+    $image = trim($_POST['image'] ?? '');
+    $excerpt = trim($_POST['excerpt'] ?? '');
+    $content = trim($_POST['content'] ?? '');
+
+    if ($title === '' || $date === '' || $author === '' || $image === '' || $excerpt === '' || $content === '') {
+        header('Location: dashboard.php');
+        exit;
+    }
+
+    $slug = slugify($title);
+    if ($action === 'update') {
+        $originalSlug = $_POST['slug'] ?? '';
+        $existingSlugs = array_column($blogs, 'slug');
+        $existingSlugs = array_values(array_filter($existingSlugs, static function ($value) use ($originalSlug) {
+            return $value !== $originalSlug;
+        }));
+
+        $baseSlug = $slug ?: $originalSlug;
+        if ($baseSlug === '') {
+            $baseSlug = 'post-' . uniqid();
+        }
+
+        $candidate = $baseSlug;
+        $counter = 2;
+        while (in_array($candidate, $existingSlugs, true)) {
+            $candidate = $baseSlug . '-' . $counter++;
+        }
+
+        foreach ($blogs as &$blog) {
+            if ($blog['slug'] === $originalSlug) {
+                $blog = [
+                    'slug' => $candidate,
+                    'title' => $title,
+                    'date' => $date,
+                    'author' => $author,
+                    'image' => $image,
+                    'excerpt' => $excerpt,
+                    'content' => $content,
+                ];
+                break;
+            }
+        }
+        unset($blog);
+    } else {
+        $existingSlugs = array_column($blogs, 'slug');
+        $baseSlug = $slug;
+        $counter = 2;
+        while (in_array($slug, $existingSlugs, true)) {
+            $slug = $baseSlug . '-' . $counter++;
+        }
+        $blogs[] = [
+            'slug' => $slug,
+            'title' => $title,
+            'date' => $date,
+            'author' => $author,
+            'image' => $image,
+            'excerpt' => $excerpt,
+            'content' => $content,
+        ];
+    }
+}
+
+if ($action === 'delete') {
+    $slug = $_POST['slug'] ?? '';
+    $blogs = array_values(array_filter($blogs, static function ($blog) use ($slug) {
+        return $blog['slug'] !== $slug;
+    }));
+}
+
+usort($blogs, static function ($a, $b) {
+    return strcmp($b['date'], $a['date']);
+});
+
+$data['blogs'] = $blogs;
+save_data($data);
+header('Location: dashboard.php');
+exit;

--- a/admin/save_stats.php
+++ b/admin/save_stats.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/config.php';
+ensure_logged_in();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: dashboard.php');
+    exit;
+}
+
+$data = load_data();
+$data['stats']['services'] = max(0, (int) ($_POST['services'] ?? 0));
+$data['stats']['clients'] = max(0, (int) ($_POST['clients'] ?? 0));
+$data['stats']['experience'] = max(0, (int) ($_POST['experience'] ?? 0));
+
+save_data($data);
+header('Location: dashboard.php');
+exit;

--- a/blog-single.html
+++ b/blog-single.html
@@ -88,8 +88,8 @@
       <div class="container">
         <div class="row no-gutters slider-text align-items-center justify-content-center">
           <div class="col-md-9 ftco-animate text-center">
-            <h1 class="mb-2 bread">Blog Single</h1>
-            <p class="breadcrumbs"><span class="mr-2"><a href="index">Home <i class="ion-ios-arrow-forward"></i></a></span> <span class="mr-2"><a href="index">Blog <i class="ion-ios-arrow-forward"></i></a></span> <span>Blog Single <i class="ion-ios-arrow-forward"></i></span></p>
+            <h1 class="mb-2 bread" id="single-hero-title">Blog</h1>
+            <p class="breadcrumbs"><span class="mr-2"><a href="index">Home <i class="ion-ios-arrow-forward"></i></a></span> <span class="mr-2"><a href="blog">Blog <i class="ion-ios-arrow-forward"></i></a></span> <span id="single-breadcrumb-title">Artigo</span></p>
           </div>
         </div>
       </div>
@@ -99,148 +99,18 @@
 			<div class="container">
 				<div class="row">
           <div class="col-lg-8 ftco-animate">
-            <h2 class="mb-3">#2. Creative WordPress Themes</h2>
-            <p>Temporibus ad error suscipit exercitationem hic molestiae totam obcaecati rerum, eius aut, in. Exercitationem atque quidem tempora maiores ex architecto voluptatum aut officia doloremque. Error dolore voluptas, omnis molestias odio dignissimos culpa ex earum nisi consequatur quos odit quasi repellat qui officiis reiciendis incidunt hic non? Debitis commodi aut, adipisci.</p>
-            <p>
-              <img src="images/image_2.jpg" alt="" class="img-fluid">
-            </p>
-            <p>Quisquam esse aliquam fuga distinctio, quidem delectus veritatis reiciendis. Nihil explicabo quod, est eos ipsum. Unde aut non tenetur tempore, nisi culpa voluptate maiores officiis quis vel ab consectetur suscipit veritatis nulla quos quia aspernatur perferendis, libero sint. Error, velit, porro. Deserunt minus, quibusdam iste enim veniam, modi rem maiores.</p>
-            <p>Odit voluptatibus, eveniet vel nihil cum ullam dolores laborum, quo velit commodi rerum eum quidem pariatur! Quia fuga iste tenetur, ipsa vel nisi in dolorum consequatur, veritatis porro explicabo soluta commodi libero voluptatem similique id quidem? Blanditiis voluptates aperiam non magni. Reprehenderit nobis odit inventore, quia laboriosam harum excepturi ea.</p>
-            <p>Adipisci vero culpa, eius nobis soluta. Dolore, maxime ullam ipsam quidem, dolor distinctio similique asperiores voluptas enim, exercitationem ratione aut adipisci modi quod quibusdam iusto, voluptates beatae iure nemo itaque laborum. Consequuntur et pariatur totam fuga eligendi vero dolorum provident. Voluptatibus, veritatis. Beatae numquam nam ab voluptatibus culpa, tenetur recusandae!</p>
-            <p>Voluptas dolores dignissimos dolorum temporibus, autem aliquam ducimus at officia adipisci quasi nemo a perspiciatis provident magni laboriosam repudiandae iure iusto commodi debitis est blanditiis alias laborum sint dolore. Dolores, iure, reprehenderit. Error provident, pariatur cupiditate soluta doloremque aut ratione. Harum voluptates mollitia illo minus praesentium, rerum ipsa debitis, inventore?</p>
-            <div class="tag-widget post-tag-container mb-5 mt-5">
-              <div class="tagcloud">
-                <a href="#" class="tag-cloud-link">Life</a>
-                <a href="#" class="tag-cloud-link">Sport</a>
-                <a href="#" class="tag-cloud-link">Tech</a>
-                <a href="#" class="tag-cloud-link">Travel</a>
+            <div id="single-blog" class="single-blog">
+              <h2 class="mb-3" id="single-title">Artigo</h2>
+              <div class="mb-3 text-muted" id="single-meta"></div>
+              <div class="mb-4" id="single-image-wrapper" style="display:none;">
+                <img id="single-image" src="" alt="Imagem do artigo" class="img-fluid">
               </div>
+              <div id="single-content" class="single-content"></div>
             </div>
-            
-            <div class="about-author d-flex p-4 bg-light">
-              <div class="bio mr-5">
-                <img src="images/person_1.jpg" alt="Image placeholder" class="img-fluid mb-4">
-              </div>
-              <div class="desc">
-                <h3>George Washington</h3>
-                <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ducimus itaque, autem necessitatibus voluptate quod mollitia delectus aut, sunt placeat nam vero culpa sapiente consectetur similique, inventore eos fugit cupiditate numquam!</p>
-              </div>
+            <div class="alert alert-info" id="single-not-found" style="display:none;">
+              O artigo que procura não foi encontrado. Volte à <a href="blog">lista de notícias</a> para continuar a leitura.
             </div>
-
-
-            <div class="pt-5 mt-5">
-              <h3 class="mb-5 h4 font-weight-bold">6 Comments</h3>
-              <ul class="comment-list">
-                <li class="comment">
-                  <div class="vcard bio">
-                    <img src="images/person_1.jpg" alt="Image placeholder">
-                  </div>
-                  <div class="comment-body">
-                    <h3>John Doe</h3>
-                    <div class="meta mb-2">June 27, 2019 at 2:21pm</div>
-                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur quidem laborum necessitatibus, ipsam impedit vitae autem, eum officia, fugiat saepe enim sapiente iste iure! Quam voluptas earum impedit necessitatibus, nihil?</p>
-                    <p><a href="#" class="reply">Reply</a></p>
-                  </div>
-                </li>
-
-                <li class="comment">
-                  <div class="vcard bio">
-                    <img src="images/person_1.jpg" alt="Image placeholder">
-                  </div>
-                  <div class="comment-body">
-                    <h3>John Doe</h3>
-                    <div class="meta mb-2">June 27, 2019 at 2:21pm</div>
-                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur quidem laborum necessitatibus, ipsam impedit vitae autem, eum officia, fugiat saepe enim sapiente iste iure! Quam voluptas earum impedit necessitatibus, nihil?</p>
-                    <p><a href="#" class="reply">Reply</a></p>
-                  </div>
-
-                  <ul class="children">
-                    <li class="comment">
-                      <div class="vcard bio">
-                        <img src="images/person_1.jpg" alt="Image placeholder">
-                      </div>
-                      <div class="comment-body">
-                        <h3>John Doe</h3>
-                        <div class="meta mb-2">June 27, 2019 at 2:21pm</div>
-                        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur quidem laborum necessitatibus, ipsam impedit vitae autem, eum officia, fugiat saepe enim sapiente iste iure! Quam voluptas earum impedit necessitatibus, nihil?</p>
-                        <p><a href="#" class="reply">Reply</a></p>
-                      </div>
-
-
-                      <ul class="children">
-                        <li class="comment">
-                          <div class="vcard bio">
-                            <img src="images/person_1.jpg" alt="Image placeholder">
-                          </div>
-                          <div class="comment-body">
-                            <h3>John Doe</h3>
-                            <div class="meta mb-2">June 27, 2019 at 2:21pm</div>
-                            <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur quidem laborum necessitatibus, ipsam impedit vitae autem, eum officia, fugiat saepe enim sapiente iste iure! Quam voluptas earum impedit necessitatibus, nihil?</p>
-                            <p><a href="#" class="reply">Reply</a></p>
-                          </div>
-
-                            <ul class="children">
-                              <li class="comment">
-                                <div class="vcard bio">
-                                  <img src="images/person_1.jpg" alt="Image placeholder">
-                                </div>
-                                <div class="comment-body">
-                                  <h3>John Doe</h3>
-                                  <div class="meta mb-2">June 27, 2019 at 2:21pm</div>
-                                  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur quidem laborum necessitatibus, ipsam impedit vitae autem, eum officia, fugiat saepe enim sapiente iste iure! Quam voluptas earum impedit necessitatibus, nihil?</p>
-                                  <p><a href="#" class="reply">Reply</a></p>
-                                </div>
-                              </li>
-                            </ul>
-                        </li>
-                      </ul>
-                    </li>
-                  </ul>
-                </li>
-
-                <li class="comment">
-                  <div class="vcard bio">
-                    <img src="images/person_1.jpg" alt="Image placeholder">
-                  </div>
-                  <div class="comment-body">
-                    <h3>John Doe</h3>
-                    <div class="meta mb-2">June 27, 2019 at 2:21pm</div>
-                    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur quidem laborum necessitatibus, ipsam impedit vitae autem, eum officia, fugiat saepe enim sapiente iste iure! Quam voluptas earum impedit necessitatibus, nihil?</p>
-                    <p><a href="#" class="reply">Reply</a></p>
-                  </div>
-                </li>
-              </ul>
-              <!-- END comment-list -->
-              
-              <div class="comment-form-wrap pt-5">
-                <h3 class="mb-5 h4 font-weight-bold">Leave a comment</h3>
-                <form action="#" class="p-5 bg-light">
-                  <div class="form-group">
-                    <label for="name">Name *</label>
-                    <input type="text" class="form-control" id="name">
-                  </div>
-                  <div class="form-group">
-                    <label for="email">Email *</label>
-                    <input type="email" class="form-control" id="email">
-                  </div>
-                  <div class="form-group">
-                    <label for="website">Website</label>
-                    <input type="url" class="form-control" id="website">
-                  </div>
-
-                  <div class="form-group">
-                    <label for="message">Message</label>
-                    <textarea name="" id="message" cols="30" rows="10" class="form-control"></textarea>
-                  </div>
-                  <div class="form-group">
-                    <input type="submit" value="Post Comment" class="btn py-3 px-4 btn-primary">
-                  </div>
-
-                </form>
-              </div>
-            </div>
-          </div> <!-- .col-md-8 -->
-
+          </div>
           <div class="col-lg-4 sidebar ftco-animate">
             <div class="sidebar-box">
               <form action="#" class="search-form">
@@ -263,39 +133,7 @@
 
             <div class="sidebar-box ftco-animate">
               <h3>Popular Articles</h3>
-              <div class="block-21 mb-4 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_1.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">Even the all-powerful Pointing has no control about the blind texts</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> June 27, 2019</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Dave Lewis</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
-              <div class="block-21 mb-4 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_2.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">Even the all-powerful Pointing has no control about the blind texts</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> June 27, 2019</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Dave Lewis</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
-              <div class="block-21 mb-4 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_3.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">Even the all-powerful Pointing has no control about the blind texts</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> June 27, 2019</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Dave Lewis</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
+              <div id="sidebar-blog-list"></div>
             </div>
 
             <div class="sidebar-box ftco-animate">
@@ -349,28 +187,7 @@
           <div class="col-md-6 col-lg-3">
             <div class="ftco-footer-widget mb-5">
               <h2 class="ftco-heading-2">Nosso Blog</h2>
-              <div class="block-21 mb-4 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_1.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">BODIVA e PNUD estreitam parceria para fortalecer...</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> Fev 28, 2025</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Admin</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
-              <div class="block-21 mb-5 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_2.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">Angola regista crescimento de 4,4% na economia...</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> Set 20, 2025</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Admin</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
+              <div id="footer-blog-list"></div>
             </div>
           </div>
           <div class="col-md-6 col-lg-3">
@@ -437,6 +254,7 @@
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBVWaKrjvy3MaE7SQ74_uJiULgl1JY0H2s&sensor=false"></script>
   <script src="js/google-map.js"></script>
   <script src="js/main.js"></script>
+  <script src="js/site-data.js"></script>
     
   </body>
 </html>

--- a/blog.html
+++ b/blog.html
@@ -96,159 +96,15 @@
     </section>
 
     <section class="ftco-section bg-light">
-			<div class="container">
-				<div class="row">
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_1.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">26</span>
-                  <span class="mos">June</span>
-                  <span class="yr">2019</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="#">Finance And Legal Working Streams Occur Throughout</a></h3>
-                <p>Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts.</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="#" class="btn btn-primary">Saber Mais<span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                	<a href="#" class="mr-2">Admin</a>
-	                	<a href="#" class="meta-chat"><span class="icon-chat"></span> 3</a>
-	                </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_2.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">26</span>
-                  <span class="mos">June</span>
-                  <span class="yr">2019</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="#">Finance And Legal Working Streams Occur Throughout</a></h3>
-                <p>Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts.</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="#" class="btn btn-primary">Saber Mais<span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                	<a href="#" class="mr-2">Admin</a>
-	                	<a href="#" class="meta-chat"><span class="icon-chat"></span> 3</a>
-	                </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_3.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">26</span>
-                  <span class="mos">June</span>
-                  <span class="yr">2019</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="#">Finance And Legal Working Streams Occur Throughout</a></h3>
-                <p>Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts.</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="#" class="btn btn-primary">Saber Mais<span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                	<a href="#" class="mr-2">Admin</a>
-	                	<a href="#" class="meta-chat"><span class="icon-chat"></span> 3</a>
-	                </p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_4.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">26</span>
-                  <span class="mos">June</span>
-                  <span class="yr">2019</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="#">Finance And Legal Working Streams Occur Throughout</a></h3>
-                <p>Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts.</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="#" class="btn btn-primary">Saber Mais<span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                	<a href="#" class="mr-2">Admin</a>
-	                	<a href="#" class="meta-chat"><span class="icon-chat"></span> 3</a>
-	                </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_5.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">26</span>
-                  <span class="mos">June</span>
-                  <span class="yr">2019</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="#">Finance And Legal Working Streams Occur Throughout</a></h3>
-                <p>Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts.</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="#" class="btn btn-primary">Saber Mais<span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                	<a href="#" class="mr-2">Admin</a>
-	                	<a href="#" class="meta-chat"><span class="icon-chat"></span> 3</a>
-	                </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_6.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">26</span>
-                  <span class="mos">June</span>
-                  <span class="yr">2019</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="#">Finance And Legal Working Streams Occur Throughout</a></h3>
-                <p>Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts.</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="#" class="btn btn-primary">Saber Mais<span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                	<a href="#" class="mr-2">Admin</a>
-	                	<a href="#" class="meta-chat"><span class="icon-chat"></span> 3</a>
-	                </p>
-                </div>
-              </div>
-            </div>
+      <div class="container">
+        <div id="blog-list" class="row"></div>
+        <div class="row">
+          <div class="col-12 text-center" id="blog-empty" style="display:none;">
+            <p class="text-muted mb-0">Nenhum artigo encontrado.</p>
           </div>
         </div>
-        <div class="row mt-5">
-          <div class="col text-center">
-            <div class="block-27">
-              <ul>
-                <li><a href="#">&lt;</a></li>
-                <li class="active"><span>1</span></li>
-                <li><a href="#">2</a></li>
-                <li><a href="#">3</a></li>
-                <li><a href="#">4</a></li>
-                <li><a href="#">5</a></li>
-                <li><a href="#">&gt;</a></li>
-              </ul>
-            </div>
-          </div>
-        </div>
-			</div>
-		</section>
+      </div>
+    </section>
 		
     <footer class="ftco-footer ftco-bg-dark ftco-section">
       <div class="container">
@@ -268,28 +124,7 @@
           <div class="col-md-6 col-lg-3">
             <div class="ftco-footer-widget mb-5">
               <h2 class="ftco-heading-2">Nosso Blog</h2>
-              <div class="block-21 mb-4 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_1.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">BODIVA e PNUD estreitam parceria para fortalecer...</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> Fev 28, 2025</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Admin</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
-              <div class="block-21 mb-5 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_2.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">Angola regista crescimento de 4,4% na economia...</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> Set 20, 2025</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Admin</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
+              <div id="footer-blog-list"></div>
             </div>
           </div>
           <div class="col-md-6 col-lg-3">
@@ -356,6 +191,7 @@
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBVWaKrjvy3MaE7SQ74_uJiULgl1JY0H2s&sensor=false"></script>
   <script src="js/google-map.js"></script>
   <script src="js/main.js"></script>
+  <script src="js/site-data.js"></script>
     
   </body>
 </html>

--- a/data/site-data.json
+++ b/data/site-data.json
@@ -1,0 +1,36 @@
+{
+  "stats": {
+    "services": 195,
+    "clients": 189,
+    "experience": 5
+  },
+  "blogs": [
+    {
+      "slug": "bodiva-e-pnud-estreitam-parceria",
+      "title": "BODIVA e PNUD estreitam parceria para fortalecer o mercado de capitais",
+      "date": "2025-02-28",
+      "author": "Admin",
+      "image": "images/image_1.jpg",
+      "excerpt": "A BODIVA e o Programa das Nações Unidas para o Desenvolvimento anunciaram novas iniciativas para dinamizar o mercado de capitais angolano.",
+      "content": "A Bolsa de Dívida e Valores de Angola (BODIVA) e o Programa das Nações Unidas para o Desenvolvimento (PNUD) assinaram um memorando de entendimento para desenvolver projectos conjuntos orientados à capacitação e ao reforço das empresas nacionais.\n\nA parceria prevê a criação de programas de formação, campanhas de educação financeira e apoio directo às pequenas e médias empresas que pretendam aceder ao mercado de capitais."
+    },
+    {
+      "slug": "angola-crescimento-economico-2025",
+      "title": "Angola regista crescimento de 4,4% na economia em 2025",
+      "date": "2025-09-20",
+      "author": "Admin",
+      "image": "images/image_2.jpg",
+      "excerpt": "Relatório do Ministério da Economia indica expansão sustentada com destaque para os sectores agrícola e energético.",
+      "content": "O Ministério da Economia e Planeamento divulgou que o Produto Interno Bruto de Angola cresceu 4,4% em 2025, impulsionado pela diversificação económica.\n\nO estudo destaca o contributo do sector agrícola, que apresentou o maior volume de exportações dos últimos cinco anos, e do sector energético, que continua a ser responsável por grande parte das receitas fiscais do país."
+    },
+    {
+      "slug": "consultoria-empresarial-estrategias-2025",
+      "title": "Consultoria empresarial: 5 estratégias para acelerar resultados",
+      "date": "2025-01-15",
+      "author": "Equipa JOMPSON",
+      "image": "images/image_3.jpg",
+      "excerpt": "Conheça cinco boas práticas que ajudam empresas a consolidarem processos e aumentarem a produtividade.",
+      "content": "A consultoria empresarial desempenha um papel essencial na definição de planos de crescimento sustentáveis. Entre as principais estratégias estão a revisão periódica de processos internos, a definição de indicadores de desempenho e a implementação de ferramentas digitais.\n\nTambém é fundamental promover a formação contínua das equipas e manter uma cultura de inovação que incentive a colaboração entre departamentos."
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
 		            <div class="block-18">
 		            	<div class="icon"><span class="flaticon-doctor"></span></div>
 		              <div class="text">
-		                <strong class="number" data-number="195">0</strong>
+                                <strong class="number" data-number="195" data-stat="services">0</strong>
 		                <span>Serviços Concluidos</span>
 		              </div>
 		            </div>
@@ -198,7 +198,7 @@
 		            <div class="block-18">
 		            	<div class="icon"><span class="flaticon-doctor"></span></div>
 		              <div class="text">
-		                <strong class="number" data-number="189">0</strong>
+                                <strong class="number" data-number="189" data-stat="clients">0</strong>
 		                <span>Clientes satisfeitos</span>
 		              </div>
 		            </div>
@@ -208,7 +208,7 @@
 		            <div class="block-18">
 		            	<div class="icon"><span class="flaticon-doctor"></span></div>
 		              <div class="text">
-		                <strong class="number" data-number="5">0</strong>
+                                <strong class="number" data-number="5" data-stat="experience">0</strong>
 		                <span>Anos de experiência</span>
 		              </div>
 		            </div>
@@ -219,245 +219,18 @@
     	</div>
     </section>
 
-    <section class="ftco-section">
-			<div class="container">
-				<div class="row justify-content-center mb-5 pb-2">
-          <div class="col-md-8 text-center heading-section ftco-animate">
-            <h2 class="mb-4">Temos o melhor para a si e a sua empresa</h2>
-            <p>O nosso propósito vai além de números: queremos gerar valor para os nossos clientes, promovendo decisões mais seguras, processos eficientes e resultados sustentáveis.</p>
-          </div>
-        </div>
-				<div class="row no-gutters">
-					<div class="col-lg-4 d-flex">
-						<div class="services-2 noborder-left text-center ftco-animate">
-							<div class="icon mt-2 d-flex justify-content-center align-items-center"><span class="flaticon-analysis"></span></div>
-							<div class="text media-body">
-								<h3>Contabilidade</h3>
-								<p>Gestão contábil completa para garantir conformidade legal e clareza financeira.</p>
-							</div>
-						</div>
-					</div>
-					<div class="col-lg-4 d-flex">
-						<div class="services-2 text-center ftco-animate">
-							<div class="icon mt-2 d-flex justify-content-center align-items-center"><span class="flaticon-business"></span></div>
-							<div class="text media-body">
-								<h3>Auditoria Financeira</h3>
-								<p>Avaliação detalhada para assegurar transparência e confiança nos números da sua empresa.</p>
-							</div>
-						</div>
-					</div>
-					<div class="col-lg-4 d-flex">
-						<div class="services-2 text-center ftco-animate">
-							<div class="icon mt-2 d-flex justify-content-center align-items-center"><span class="flaticon-insurance"></span></div>
-							<div class="text media-body">
-								<h3>Assessoria Fiscal</h3>
-								<p>Orientação especializada para otimizar impostos e manter-se em conformidade com a legislação.</p>
-							</div>
-						</div>
-					</div>
-					<div class="col-lg-4 d-flex">
-						<div class="services-2 noborder-left noborder-bottom text-center ftco-animate">
-							<div class="icon mt-2 d-flex justify-content-center align-items-center"><span class="flaticon-money"></span></div>
-							<div class="text media-body">
-								<h3>Consultoria Financeira e Gestão Orçamental</h3>
-								<p>Estratégias personalizadas para controlar custos, melhorar resultados e apoiar o crescimento.</p>
-							</div>
-						</div>
-					</div>
-					<div class="col-lg-4 d-flex">
-						<div class="services-2 text-center noborder-bottom ftco-animate">
-							<div class="icon mt-2 d-flex justify-content-center align-items-center"><span class="flaticon-rating"></span></div>
-							<div class="text media-body">
-								<h3>Inventário de Bens Patrimoniais</h3>
-								<p>Organização e valorização do patrimônio da empresa com relatórios precisos.</p>
-							</div>
-						</div>
-					</div>
-					<div class="col-lg-4 d-flex">
-						<div class="services-2 text-center noborder-bottom ftco-animate">
-							<div class="icon mt-2 d-flex justify-content-center align-items-center"><span class="flaticon-search-engine"></span></div>
-							<div class="text media-body">
-								<h3>Formação Profissional</h3>
-								<p>Capacitação prática para equipas e gestores, fortalecendo competências e desempenho.</p>
-							</div>
-						</div>
-					</div>
-				</div>
-			</div>
-		</section>
-		
-		<section class="ftco-intro ftco-no-pb img" style="background-image: url(images/bg_1.jpg);">
-    	<div class="container">
-    		<div class="row justify-content-center">
-          <div class="col-lg-9 col-md-8 d-flex align-items-center heading-section heading-section-white ftco-animate">
-            <h2 class="mb-3 mb-md-0">Você sempre recebe a melhor orientação</h2>
-          </div>
-          <div class="col-lg-3 col-md-4 ftco-animate">
-          	<p class="mb-0"><a href="https://wa.link/2vv9fk" class="btn btn-white py-3 px-4">Solicitar Orçamento</a></p>
-          </div>
-        </div>	
-    	</div>
-    </section>
-
-	
-
-		<section class="ftco-section bg-light">
-			<div class="container">
-				<div class="row justify-content-center mb-5 pb-2">
+    <section class="ftco-section bg-light">
+      <div class="container">
+        <div class="row justify-content-center mb-5 pb-2">
           <div class="col-md-8 text-center heading-section ftco-animate">
             <h2 class="mb-4"><span>Nosso</span> Blog</h2>
-            
-        </div>
-				<div class="row">
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_1.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">04</span>
-                  <span class="mos">Mar</span>
-                  <span class="yr">2025</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="economia">Economia angolana cresceu 4,4% em 2024
-</a></h3>
-                <p>O produto interno bruto (PIB) de Angola cresceu 4,4% em 2024 face ao ano anterior, segundo dados preliminares divulgados pelo...</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="economia" class="btn btn-primary">Saber Mais<span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                	
-	                </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_2.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">29</span>
-                  <span class="mos">Fev</span>
-                  <span class="yr">2025</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="bodiva">BODIVA e PNUD estreitam parceria para fortalecer as finanças...</a></h3>
-                <p>A assinatura deste Memorando reforça o compromisso de ambas as instituições em criar...</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="bodiva" class="btn btn-primary">Saber Mais<span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                
-	                </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="col-md-6 col-lg-4 ftco-animate">
-            <div class="blog-entry">
-              <a href="blog-single" class="block-20 d-flex align-items-end" style="background-image: url('images/image_3.jpg');">
-								<div class="meta-date text-center p-2">
-                  <span class="day">28</span>
-                  <span class="mos">Fev</span>
-                  <span class="yr">2025</span>
-                </div>
-              </a>
-              <div class="text bg-white p-4">
-                <h3 class="heading"><a href="#">Ano 2021: AGT proíbe utilização de blocos de factura</a></h3>
-                <p>A proibição é estendida às facturas emitidas em 'softwares' de facturação, com referência ao exercício económico de 2020, respeitando-se, desta forma...</p>
-                <div class="d-flex align-items-center mt-4">
-	                <p class="mb-0"><a href="#" class="btn btn-primary">Saber Mais <span class="ion-ios-arrow-round-forward"></span></a></p>
-	                <p class="ml-auto mb-0">
-	                	
-	                </p>
-                </div>
-              </div>
-            </div>
           </div>
         </div>
-			</div>
-		</section>
-
-		<section class="ftco-section testimony-section">
-      <div class="container">
-        <div class="row justify-content-center mb-5">
-          <div class="col-md-8 text-center heading-section ftco-animate">
-            <h2 class="mb-4">Clientes Satisfeitos</h2>
-           
-          </div>
-        </div>
-        <div class="row ftco-animate justify-content-center">
-          <div class="col-md-12">
-            <div class="carousel-testimony owl-carousel">
-              <div class="item">
-                <div class="testimony-wrap d-flex">
-                  <div class="user-img" style="background-image: url(images/person_1.jpg)">
-                  </div>
-                  <div class="text pl-4">
-                  	<span class="quote d-flex align-items-center justify-content-center">
-                      <i class="icon-quote-left"></i>
-                    </span>
-                    <p>“A JOMPSON transformou a forma como gerimos a contabilidade da nossa empresa. Hoje temos relatórios claros e decisões muito mais seguras.”</p>
-                    <p class="name">Ana Rodrigues</p>
-                    <span class="position">Diretora Financeira</span>
-                  </div>
-                </div>
-              </div>
-              <div class="item">
-                <div class="testimony-wrap d-flex">
-                  <div class="user-img" style="background-image: url(images/person_2.jpg)">
-                  </div>
-                  <div class="text pl-4">
-                  	<span class="quote d-flex align-items-center justify-content-center">
-                      <i class="icon-quote-left"></i>
-                    </span>
-                    <p>“Com a consultoria estratégica da JOMPSON conseguimos reduzir custos e aumentar a rentabilidade. Um parceiro essencial para o meu negócio.”</p>
-                    <p class="name">Carlos Menezes</p>
-                    <span class="position">Empresário</span>
-                  </div>
-                </div>
-              </div>
-              <div class="item">
-                <div class="testimony-wrap d-flex">
-                  <div class="user-img" style="background-image: url(images/person_3.jpg)">
-                  </div>
-                  <div class="text pl-4">
-                  	<span class="quote d-flex align-items-center justify-content-center">
-                      <i class="icon-quote-left"></i>
-                    </span>
-                    <p>“A formação profissional oferecida pela JOMPSON fez toda a diferença na qualificação da nossa equipa. O impacto foi imediato na produtividade.”</p>
-                    <p class="name">Mariana Silva</p>
-                    <span class="position">Gestora de RH</span>
-                  </div>
-                </div>
-              </div>
-              <div class="item">
-                <div class="testimony-wrap d-flex">
-                  <div class="user-img" style="background-image: url(images/person_4.jpg)">
-                  </div>
-                  <div class="text pl-4">
-                  	<span class="quote d-flex align-items-center justify-content-center">
-                      <i class="icon-quote-left"></i>
-                    </span>
-                    <p>“Precisávamos de apoio em auditoria e gestão financeira, e a JOMPSON superou as nossas expectativas. Transparência e confiança em cada etapa.”</p>
-                    <p class="name">João Pereira</p>
-                    <span class="position">CEO de Startup</span>
-                  </div>
-                </div>
-              </div>
-              <div class="item">
-                <div class="testimony-wrap d-flex">
-                  <div class="user-img" style="background-image: url(images/person_1.jpg)">
-                  </div>
-                  <div class="text pl-4">
-                  	<span class="quote d-flex align-items-center justify-content-center">
-                      <i class="icon-quote-left"></i>
-                    </span>
-                    <p>“Graças à assessoria fiscal da JOMPSON conseguimos manter tudo em conformidade legal e ainda otimizar tributos. Uma equipa que transmite segurança.”</p>
-                    <p class="name">Beatriz Costa</p>
-                    <span class="position">Empresária </span>
-                  </div>
-                </div>
-              </div>
+        <div class="row">
+          <div class="col-12">
+            <div id="home-blog-list" class="row"></div>
+            <div class="text-center" id="home-blog-empty" style="display:none;">
+              <p class="text-muted mb-0">Nenhum artigo publicado no momento. Volte em breve!</p>
             </div>
           </div>
         </div>
@@ -483,28 +256,7 @@
           <div class="col-md-6 col-lg-3">
             <div class="ftco-footer-widget mb-5">
               <h2 class="ftco-heading-2">Nosso Blog</h2>
-              <div class="block-21 mb-4 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_1.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">BODIVA e PNUD estreitam parceria para fortalecer...</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> Fev 28, 2025</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Admin</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
-              <div class="block-21 mb-5 d-flex">
-                <a class="blog-img mr-4" style="background-image: url(images/image_2.jpg);"></a>
-                <div class="text">
-                  <h3 class="heading"><a href="#">Angola regista crescimento de 4,4% na economia...</a></h3>
-                  <div class="meta">
-                    <div><a href="#"><span class="icon-calendar"></span> Set 20, 2025</a></div>
-                    <div><a href="#"><span class="icon-person"></span> Admin</a></div>
-                    <div><a href="#"><span class="icon-chat"></span> 19</a></div>
-                  </div>
-                </div>
-              </div>
+              <div id="footer-blog-list"></div>
             </div>
           </div>
           <div class="col-md-6 col-lg-3">
@@ -571,6 +323,7 @@
   <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBVWaKrjvy3MaE7SQ74_uJiULgl1JY0H2s&sensor=false"></script>
   <script src="js/google-map.js"></script>
   <script src="js/main.js"></script>
-    
+  <script src="js/site-data.js"></script>
+
   </body>
 </html>

--- a/js/site-data.js
+++ b/js/site-data.js
@@ -1,0 +1,315 @@
+(function () {
+  const DATA_URL = 'data/site-data.json';
+
+  fetch(DATA_URL, { cache: 'no-store' })
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error('Não foi possível carregar os dados do site.');
+      }
+      return response.json();
+    })
+    .then((data) => {
+      if (!data) return;
+      renderStats(data.stats || {});
+      renderHomeBlog(data.blogs || []);
+      renderBlogList(data.blogs || []);
+      renderSingleBlog(data.blogs || []);
+      renderFooterBlog(data.blogs || []);
+      renderSidebarBlog(data.blogs || []);
+    })
+    .catch((error) => {
+      console.error(error);
+    });
+
+  function renderStats(stats) {
+    if (!stats) return;
+    const formatter = new Intl.NumberFormat('pt-PT');
+    document.querySelectorAll('[data-stat]').forEach((element) => {
+      const key = element.getAttribute('data-stat');
+      const value = typeof stats[key] !== 'undefined' ? Number(stats[key]) : null;
+      if (value === null || Number.isNaN(value)) return;
+      element.setAttribute('data-number', String(value));
+      element.textContent = formatter.format(value);
+    });
+  }
+
+  function renderHomeBlog(blogs) {
+    const container = document.getElementById('home-blog-list');
+    const emptyState = document.getElementById('home-blog-empty');
+    if (!container) return;
+    container.innerHTML = '';
+    if (!blogs.length) {
+      if (emptyState) emptyState.style.display = 'block';
+      return;
+    }
+    blogs.slice(0, 3).forEach((post) => {
+      container.appendChild(createBlogCard(post));
+    });
+    if (emptyState) emptyState.style.display = 'none';
+  }
+
+  function renderBlogList(blogs) {
+    const list = document.getElementById('blog-list');
+    const empty = document.getElementById('blog-empty');
+    if (!list) return;
+    list.innerHTML = '';
+    if (!blogs.length) {
+      if (empty) empty.style.display = 'block';
+      return;
+    }
+    blogs.forEach((post) => {
+      list.appendChild(createBlogCard(post, { showExcerpt: true }));
+    });
+    if (empty) empty.style.display = 'none';
+  }
+
+  function renderSingleBlog(blogs) {
+    const params = new URLSearchParams(window.location.search);
+    const slug = params.get('slug');
+    const singleContainer = document.getElementById('single-blog');
+    const titleEl = document.getElementById('single-title');
+    const metaEl = document.getElementById('single-meta');
+    const contentEl = document.getElementById('single-content');
+    const heroTitle = document.getElementById('single-hero-title');
+    const breadcrumbTitle = document.getElementById('single-breadcrumb-title');
+    const imageWrapper = document.getElementById('single-image-wrapper');
+    const imageEl = document.getElementById('single-image');
+    const notFound = document.getElementById('single-not-found');
+
+    if (!singleContainer || !titleEl || !metaEl || !contentEl) return;
+
+    const post = blogs.find((item) => item.slug === slug) || null;
+    if (!post) {
+      if (notFound) notFound.style.display = 'block';
+      singleContainer.style.display = 'none';
+      if (heroTitle) heroTitle.textContent = 'Blog';
+      if (breadcrumbTitle) breadcrumbTitle.textContent = 'Artigo não encontrado';
+      return;
+    }
+
+    if (notFound) notFound.style.display = 'none';
+    singleContainer.style.display = 'block';
+    titleEl.textContent = post.title;
+    if (heroTitle) heroTitle.textContent = post.title;
+    if (breadcrumbTitle) breadcrumbTitle.textContent = post.title;
+    metaEl.textContent = `${formatDate(post.date)} · ${post.author}`;
+
+    if (post.image && imageEl && imageWrapper) {
+      imageEl.src = post.image;
+      imageEl.alt = post.title;
+      imageWrapper.style.display = 'block';
+    } else if (imageWrapper) {
+      imageWrapper.style.display = 'none';
+    }
+
+    contentEl.innerHTML = formatContent(post.content);
+  }
+
+  function renderFooterBlog(blogs) {
+    const footerContainer = document.getElementById('footer-blog-list');
+    if (!footerContainer) return;
+    footerContainer.innerHTML = '';
+    blogs.slice(0, 2).forEach((post) => {
+      footerContainer.appendChild(createFooterItem(post));
+    });
+  }
+
+  function renderSidebarBlog(blogs) {
+    const sidebarContainer = document.getElementById('sidebar-blog-list');
+    if (!sidebarContainer) return;
+    sidebarContainer.innerHTML = '';
+    blogs.slice(0, 3).forEach((post) => {
+      sidebarContainer.appendChild(createSidebarItem(post));
+    });
+  }
+
+  function createBlogCard(post, options) {
+    const showExcerpt = options && options.showExcerpt;
+    const col = document.createElement('div');
+    col.className = 'col-md-6 col-lg-4 ftco-animate';
+
+    const entry = document.createElement('div');
+    entry.className = 'blog-entry';
+
+    const link = document.createElement('a');
+    link.className = 'block-20 d-flex align-items-end';
+    link.href = `blog-single.html?slug=${encodeURIComponent(post.slug)}`;
+    if (post.image) {
+      link.style.backgroundImage = `url('${post.image}')`;
+    }
+
+    const meta = document.createElement('div');
+    meta.className = 'meta-date text-center p-2';
+    const dateParts = getDateParts(post.date);
+    meta.innerHTML = `
+      <span class="day">${dateParts.day}</span>
+      <span class="mos">${dateParts.month}</span>
+      <span class="yr">${dateParts.year}</span>
+    `;
+
+    link.appendChild(meta);
+
+    const text = document.createElement('div');
+    text.className = 'text bg-white p-4';
+
+    const heading = document.createElement('h3');
+    heading.className = 'heading';
+    const headingLink = document.createElement('a');
+    headingLink.href = link.href;
+    headingLink.textContent = post.title;
+    heading.appendChild(headingLink);
+
+    text.appendChild(heading);
+
+    if (showExcerpt) {
+      const paragraph = document.createElement('p');
+      paragraph.textContent = post.excerpt;
+      text.appendChild(paragraph);
+    }
+
+    const footer = document.createElement('div');
+    footer.className = 'd-flex align-items-center mt-4';
+
+    const more = document.createElement('p');
+    more.className = 'mb-0';
+    const moreLink = document.createElement('a');
+    moreLink.className = 'btn btn-primary';
+    moreLink.href = link.href;
+    moreLink.innerHTML = 'Saber Mais<span class="ion-ios-arrow-round-forward"></span>';
+    more.appendChild(moreLink);
+
+    const metaInfo = document.createElement('p');
+    metaInfo.className = 'ml-auto mb-0';
+    metaInfo.innerHTML = `
+      <a href="${link.href}" class="mr-2">${post.author}</a>
+      <span class="text-muted">${formatDate(post.date)}</span>
+    `;
+
+    footer.appendChild(more);
+    footer.appendChild(metaInfo);
+
+    text.appendChild(footer);
+
+    entry.appendChild(link);
+    entry.appendChild(text);
+    col.appendChild(entry);
+    return col;
+  }
+
+  function createFooterItem(post) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'block-21 mb-4 d-flex';
+
+    const imageLink = document.createElement('a');
+    imageLink.className = 'blog-img mr-4';
+    imageLink.href = `blog-single.html?slug=${encodeURIComponent(post.slug)}`;
+    if (post.image) {
+      imageLink.style.backgroundImage = `url(${post.image})`;
+    }
+
+    const text = document.createElement('div');
+    text.className = 'text';
+
+    const heading = document.createElement('h3');
+    heading.className = 'heading';
+    const link = document.createElement('a');
+    link.href = imageLink.href;
+    link.textContent = post.title;
+    heading.appendChild(link);
+
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    meta.innerHTML = `
+      <div><a href="${link.href}"><span class="icon-calendar"></span> ${formatDate(post.date)}</a></div>
+      <div><a href="${link.href}"><span class="icon-person"></span> ${post.author}</a></div>
+    `;
+
+    text.appendChild(heading);
+    text.appendChild(meta);
+
+    wrapper.appendChild(imageLink);
+    wrapper.appendChild(text);
+    return wrapper;
+  }
+
+  function createSidebarItem(post) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'block-21 mb-4 d-flex';
+
+    const imageLink = document.createElement('a');
+    imageLink.className = 'blog-img mr-4';
+    imageLink.href = `blog-single.html?slug=${encodeURIComponent(post.slug)}`;
+    if (post.image) {
+      imageLink.style.backgroundImage = `url(${post.image})`;
+    }
+
+    const text = document.createElement('div');
+    text.className = 'text';
+
+    const heading = document.createElement('h3');
+    heading.className = 'heading';
+    const link = document.createElement('a');
+    link.href = imageLink.href;
+    link.textContent = post.title;
+    heading.appendChild(link);
+
+    const meta = document.createElement('div');
+    meta.className = 'meta';
+    meta.innerHTML = `
+      <div><a href="${link.href}"><span class="icon-calendar"></span> ${formatDate(post.date)}</a></div>
+      <div><a href="${link.href}"><span class="icon-person"></span> ${post.author}</a></div>
+    `;
+
+    text.appendChild(heading);
+    text.appendChild(meta);
+
+    wrapper.appendChild(imageLink);
+    wrapper.appendChild(text);
+    return wrapper;
+  }
+
+  function getDateParts(dateString) {
+    const date = new Date(dateString || '');
+    if (Number.isNaN(date.getTime())) {
+      return { day: '--', month: '--', year: '' };
+    }
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = capitalize(date.toLocaleString('pt-PT', { month: 'short' }));
+    const year = String(date.getFullYear());
+    return { day, month, year };
+  }
+
+  function formatDate(dateString) {
+    const date = new Date(dateString || '');
+    if (Number.isNaN(date.getTime())) {
+      return dateString || '';
+    }
+    return capitalize(new Intl.DateTimeFormat('pt-PT', {
+      day: '2-digit',
+      month: 'short',
+      year: 'numeric'
+    }).format(date));
+  }
+
+  function formatContent(text) {
+    if (!text) return '';
+    return text
+      .split(/\n\s*\n/)
+      .map((paragraph) => `<p>${escapeHtml(paragraph).replace(/\n/g, '<br>')}</p>`)
+      .join('');
+  }
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function capitalize(value) {
+    if (!value) return '';
+    return value.charAt(0).toUpperCase() + value.slice(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a password-protected PHP dashboard for updating homepage statistics and blog posts
- persist stats and entries in `data/site-data.json` and expose CRUD helpers for maintaining the dataset
- load counters and blog sections dynamically on the public pages with a shared JavaScript renderer

## Testing
- php -l admin/*.php

------
https://chatgpt.com/codex/tasks/task_e_68de5755faa8832a883f175cefaa5269